### PR TITLE
feat: configure menu structure and CRUD operations

### DIFF
--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -15,7 +15,12 @@ class MenuController {
 
     async getAllMenus(req, res, next) {
         try {
-            
+            const menus = await this.#service.getAllMenus();
+
+            return res.status(StatusCodes.OK).json({
+                statusCode: StatusCodes.OK,
+                menus
+            })
         } catch (error) {
             next(error);
         }

--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -1,0 +1,53 @@
+const autoBind = require("auto-bind");
+const menuService = require("../services/menu.service");
+
+class MenuController {
+    #service;
+
+    constructor() {
+        autoBind(this);
+        this.#service = menuService;
+    };
+
+    async getAllMenus(req, res, next) {
+        try {
+            
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async createMenu(req, res, next) {
+        try {
+            
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async updateMenu(req, res, next) {
+        try {
+            
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async deleteMenu(req, res, next) {
+        try {
+            
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getMenusForAdmin(req, res, next) {
+        try {
+            
+        } catch (error) {
+            next(error);
+        }
+    }
+};
+
+module.exports = new MenuController();

--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -76,14 +76,6 @@ class MenuController {
             next(error);
         }
     }
-
-    async getMenusForAdmin(req, res, next) {
-        try {
-            
-        } catch (error) {
-            next(error);
-        }
-    }
 };
 
 module.exports = new MenuController();

--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -3,6 +3,7 @@ const { StatusCodes } = require("http-status-codes");
 
 const menuService = require("../services/menu.service");
 const { menuValidation } = require("../validations/menu.validation");
+const { objectIdValidation } = require("../validations/id.validation");
 
 class MenuController {
     #service;
@@ -45,7 +46,16 @@ class MenuController {
 
     async deleteMenu(req, res, next) {
         try {
-            
+            const { id } = req.params;
+
+            await objectIdValidation.validateAsync({ id });
+
+            await this.#service.deleteMenu(id);
+
+            return res.status(StatusCodes.OK).json({
+                statusCode: StatusCodes.OK,
+                message: "دسته بندی با موفقیت حذف شد"
+            });
         } catch (error) {
             next(error);
         }

--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -1,5 +1,8 @@
 const autoBind = require("auto-bind");
+const { StatusCodes } = require("http-status-codes");
+
 const menuService = require("../services/menu.service");
+const { menuValidation } = require("../validations/menu.validation");
 
 class MenuController {
     #service;
@@ -19,7 +22,14 @@ class MenuController {
 
     async createMenu(req, res, next) {
         try {
-            
+            const menuData = await menuValidation.validateAsync(req.body);
+
+            await this.#service.createMenu(menuData);
+
+            return res.status(StatusCodes.CREATED).json({
+                statusCode: StatusCodes.CREATED,
+                message: "دسته بندی با موفقیت اضافه شد"
+            });
         } catch (error) {
             next(error);
         }

--- a/src/controllers/menu.controller.js
+++ b/src/controllers/menu.controller.js
@@ -38,7 +38,18 @@ class MenuController {
 
     async updateMenu(req, res, next) {
         try {
-            
+            const { id } = req.params;
+
+            await objectIdValidation.validateAsync({ id });
+
+            const menuData = await menuValidation.validateAsync(req.body);
+
+            await this.#service.updateMenu(id, menuData);
+
+            return res.status(StatusCodes.OK).json({
+                statusCode: StatusCodes.OK,
+                message: "دسته بندی با موفقیت ویرایش شد"
+            })
         } catch (error) {
             next(error);
         }

--- a/src/models/menu.model.js
+++ b/src/models/menu.model.js
@@ -12,11 +12,29 @@ const MenuSchema = new Schema({
     parent: {
         type: Schema.Types.ObjectId,
         ref: "menu",
-        required: false
+        required: false,
+        default: null
     }
 }, {
-    timestamps: true
+    timestamps: true,
+    id: false,
+    toJSON: {
+        virtuals: true
+    }
 });
+
+MenuSchema.virtual("subMenus", {
+    ref: "menu",
+    localField: "_id",
+    foreignField: "parent"
+});
+
+function autoPopulate(next) {
+    this.populate([{ path: "subMenus", select: { __v: 0, id: 0 }}]);
+    next();
+}
+
+MenuSchema.pre("find", autoPopulate).pre("findOne", autoPopulate);
 
 const MenuModel = mongoose.model("menu", MenuSchema);
 

--- a/src/models/menu.model.js
+++ b/src/models/menu.model.js
@@ -1,0 +1,23 @@
+const { Schema, default: mongoose } = require("mongoose");
+
+const MenuSchema = new Schema({
+    title: {
+        type: String,
+        required: true
+    },
+    slug: {
+        type: String,
+        required: true
+    },
+    parent: {
+        type: Schema.Types.ObjectId,
+        ref: "menu",
+        required: false
+    }
+}, {
+    timestamps: true
+});
+
+const MenuModel = mongoose.model("menu", MenuSchema);
+
+module.exports = MenuModel;

--- a/src/routes/index.routes.js
+++ b/src/routes/index.routes.js
@@ -7,6 +7,7 @@ const { CommentRoutes } = require("./comment.routes");
 const { NotificationRoutes } = require("./notification.routes");
 const { ContactRoutes } = require("./contact.routes");
 const { NewsLetterRoutes } = require("./newsletter.routes");
+const { MenuRoutes } = require("./menu.routes");
 
 const router = Router();
 
@@ -17,7 +18,8 @@ router.use('/blogs', BlogRoutes);
 router.use(`/comments`, CommentRoutes);
 router.use(`/notifications`, NotificationRoutes);
 router.use(`/contact`, ContactRoutes);
-router.use(`/newsletter`, NewsLetterRoutes)
+router.use(`/newsletter`, NewsLetterRoutes);
+router.use(`/menu`, MenuRoutes);
 
 module.exports = {
     AllRoutes: router

--- a/src/routes/menu.routes.js
+++ b/src/routes/menu.routes.js
@@ -4,7 +4,6 @@ const MenuController = require("../controllers/menu.controller");
 const router = Router();
 
 router.get(`/`, MenuController.getAllMenus);
-router.get(`/all`, MenuController.getMenusForAdmin);
 router.post(`/create`, MenuController.createMenu);
 router.put(`/update/:id`, MenuController.updateMenu);
 router.delete(`/delete/:id`, MenuController.deleteMenu);

--- a/src/routes/menu.routes.js
+++ b/src/routes/menu.routes.js
@@ -1,0 +1,14 @@
+const { Router } = require("express");
+const MenuController = require("../controllers/menu.controller");
+
+const router = Router();
+
+router.get(`/`, MenuController.getAllMenus);
+router.get(`/all`, MenuController.getMenusForAdmin);
+router.post(`/create`, MenuController.createMenu);
+router.put(`/update/:id`, MenuController.updateMenu);
+router.delete(`/delete/:id`, MenuController.deleteMenu);
+
+module.exports = {
+    MenuRoutes: router
+}

--- a/src/routes/swagger/menu.swagger.js
+++ b/src/routes/swagger/menu.swagger.js
@@ -1,6 +1,6 @@
 /**
  * @swagger
- *  componets:
+ *  components:
  *      schemas:
  *          Menu:
  *              type: object

--- a/src/routes/swagger/menu.swagger.js
+++ b/src/routes/swagger/menu.swagger.js
@@ -1,0 +1,113 @@
+/**
+ * @swagger
+ *  componets:
+ *      schemas:
+ *          Menu:
+ *              type: object
+ *              required:
+ *                  -   title
+ *                  -   slug
+ *              properties:
+ *                  title:
+ *                      type: string
+ *                      description: menu title
+ *                  slug:
+ *                      type: string
+ *                      description: menu slug
+ *                  parent:
+ *                      type: string
+ *                      description: menu parent
+ */
+
+/**
+ * @swagger
+ *  /menu:
+ *      get:
+ *          tags: [Menu]
+ *          summary: get menu
+ *          responses:
+ *              200:
+ *                  description: get menu
+ *              400:
+ *                  description: bad Request
+ *              500:
+ *                  description: server error
+ */
+
+/**
+ * @swagger
+ *  /menu/all:
+ *      get:
+ *          tags: [Menu]
+ *          summary: get all menu
+ *          responses:
+ *              200:
+ *                  description: get all menu
+ *              400:
+ *                  description: bad Request
+ *              500:
+ *                  description: server error
+ */
+
+/**
+ * @swagger
+ *  /menu/create:
+ *      post:
+ *          tags: [Menu]
+ *          summary: create menu
+ *          requestBody:
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          $ref: '#/components/schemas/Menu'
+ *                  application/x-www-form-urlencoded:
+ *                      schema:
+ *                          $ref: '#/components/schemas/Menu'
+ *          responses:
+ *              201:
+ *                  description: success
+ *              400:
+ *                  description: bad Request
+ *              500:
+ *                  description: server error
+ */
+
+/**
+ * @swagger
+ *  /menu/update/{id}:
+ *      put:
+ *          tags: [Menu]
+ *          summary: update menu
+ *          parameters:
+ *              - in: path
+ *                required: true
+ *                name: id
+ *                type: string
+ *          responses:
+ *              200:
+ *                  description: update menu
+ *              400:
+ *                  description: bad Request
+ *              500:
+ *                  description: server error
+ */
+
+/**
+ * @swagger
+ *  /menu/delete/{id}:
+ *      delete:
+ *          tags: [Menu]
+ *          summary: delete menu
+ *          parameters:
+ *              - in: path
+ *                required: true
+ *                name: id
+ *                type: string
+ *          responses:
+ *              200:
+ *                  description: success
+ *              400:
+ *                  description: bad Request
+ *              500:
+ *                  description: server error
+ */

--- a/src/routes/swagger/menu.swagger.js
+++ b/src/routes/swagger/menu.swagger.js
@@ -83,6 +83,14 @@
  *                required: true
  *                name: id
  *                type: string
+ *          requestBody:
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          $ref: '#/components/schemas/Menu'
+ *                  application/x-www-form-urlencoded:
+ *                      schema:
+ *                          $ref: '#/components/schemas/Menu'
  *          responses:
  *              200:
  *                  description: update menu

--- a/src/routes/swagger/menu.swagger.js
+++ b/src/routes/swagger/menu.swagger.js
@@ -36,21 +36,6 @@
 
 /**
  * @swagger
- *  /menu/all:
- *      get:
- *          tags: [Menu]
- *          summary: get all menu
- *          responses:
- *              200:
- *                  description: get all menu
- *              400:
- *                  description: bad Request
- *              500:
- *                  description: server error
- */
-
-/**
- * @swagger
  *  /menu/create:
  *      post:
  *          tags: [Menu]

--- a/src/routes/swagger/tags.swagger.js
+++ b/src/routes/swagger/tags.swagger.js
@@ -17,4 +17,5 @@
  *        description: contact controll mangement route
  *      - name: NewsLetter
  *        description: newsletter controll mangement route
+ *      - name: Menu
  */

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -24,8 +24,13 @@ class MenuService {
         if (!newMenu) throw new createHttpError.InternalServerError("دسته بندی ایجاد نشد");
     }
 
-    async updateMenu() {
-        
+    async updateMenu(id, { title, slug, parent }) {
+        await this.checkExistById({ id });
+        await this.checkExistWithTitle({ title });
+        await this.checkExistSlug({ slug });
+
+        const resultUpdate = await this.#model.updateOne({ _id: id }, { $set: { title, slug, parent } });
+        if (!resultUpdate.modifiedCount) throw new createHttpError.InternalServerError("بروزرسانی دسته بندی انجام نشد");
     }
 
     async deleteMenu(id) {

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -1,4 +1,6 @@
 const autoBind = require("auto-bind");
+const createHttpError = require("http-errors");
+
 const MenuModel = require("../models/menu.model");
 
 class MenuService {
@@ -13,8 +15,13 @@ class MenuService {
         
     }
 
-    async createMenu() {
+    async createMenu({ title, slug, parent }) {
+        await this.checkExistWithTitle({ title });
+        await this.checkExistSlug({ slug });
         
+        const newMenu = await this.#model.create({ title, slug, parent });
+
+        if (!newMenu) throw new createHttpError.InternalServerError("دسته بندی ایجاد نشد");
     }
 
     async updateMenu() {
@@ -27,6 +34,16 @@ class MenuService {
 
     async getMenusForAdmin() {
         
+    };
+
+    async checkExistWithTitle({ title }) {
+        const existTitle = await this.#model.findOne({ title: title });
+        if (existTitle) throw new createHttpError.Conflict("نام عنوان تکراری است");
+    }
+
+    async checkExistSlug({ slug }) {
+        const existSlug = await this.#model.findOne({ slug: slug });
+        if (existSlug) throw new createHttpError.Conflict("نام slug تکراری است");
     }
 };
 

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -1,0 +1,33 @@
+const autoBind = require("auto-bind");
+const MenuModel = require("../models/menu.model");
+
+class MenuService {
+    #model;
+
+    constructor() {
+        autoBind(this);
+        this.#model = MenuModel;
+    };
+
+    async getAllMenus() {
+        
+    }
+
+    async createMenu() {
+        
+    }
+
+    async updateMenu() {
+        
+    }
+
+    async deleteMenu() {
+        
+    }
+
+    async getMenusForAdmin() {
+        
+    }
+};
+
+module.exports = new MenuService();

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -12,7 +12,8 @@ class MenuService {
     };
 
     async getAllMenus() {
-        
+        const menus = await this.#model.find({ parent: null }, { __v: 0 });
+        return menus;
     }
 
     async createMenu({ title, slug, parent }) {

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -28,13 +28,23 @@ class MenuService {
         
     }
 
-    async deleteMenu() {
-        
+    async deleteMenu(id) {
+        const menu = await this.checkExistById({ id });
+
+        const resultDelete = await this.#model.deleteOne({ _id: menu._id });
+
+        if (!resultDelete.deletedCount) throw new createHttpError.InternalServerError("حذف دسته بندی انجام نشد");
     }
 
     async getMenusForAdmin() {
         
     };
+
+    async checkExistById({ id }) {
+        const menu = await this.#model.findById({ _id: id });
+        if (!menu) throw new createHttpError.NotFound("دسته بندی وجود ندارد");
+        return menu;
+    }
 
     async checkExistWithTitle({ title }) {
         const existTitle = await this.#model.findOne({ title: title });

--- a/src/services/menu.service.js
+++ b/src/services/menu.service.js
@@ -42,10 +42,6 @@ class MenuService {
         if (!resultDelete.deletedCount) throw new createHttpError.InternalServerError("حذف دسته بندی انجام نشد");
     }
 
-    async getMenusForAdmin() {
-        
-    };
-
     async checkExistById({ id }) {
         const menu = await this.#model.findById({ _id: id });
         if (!menu) throw new createHttpError.NotFound("دسته بندی وجود ندارد");

--- a/src/validations/menu.validation.js
+++ b/src/validations/menu.validation.js
@@ -1,0 +1,14 @@
+const Joi = require("joi");
+const createHttpError = require("http-errors");
+
+const { MongoIDPattern } = require("../constants/constants");
+
+const menuValidation = Joi.object({
+    title: Joi.string().min(3).max(20).required("عنوان نمی تواند خالی باشد").error(createHttpError.BadRequest("عنوان صحیح نمی باشد")),
+    slug: Joi.string().required("slug نمی تواند خالی باشد").error(createHttpError.BadRequest("slug صحیح نمی باشد")),
+    parent: Joi.string().pattern(MongoIDPattern).error(createHttpError.BadRequest("شناسه والد صحیح نمی باشد")),
+});
+
+module.exports = {
+    menuValidation
+}


### PR DESCRIPTION
This pull request includes the initial configuration and setup for the menu structure, along with the implementation of CRUD operations and necessary validations. The following changes have been made:

Configured the menu structure to support hierarchical relationships.
Added the create menu endpoint with validation and a service layer.
Implemented the delete menu functionality with proper validation.
Added the update menu endpoint, ensuring data validation before processing.
Implemented the get all menus endpoint to retrieve the list of menus, supporting nested submenus.
Removed the redundant get all menu for admin endpoint as part of the cleanup.